### PR TITLE
Roll back Script

### DIFF
--- a/components/PrismicScript.js
+++ b/components/PrismicScript.js
@@ -3,7 +3,7 @@ import { apiEndpoint } from 'prismic-configuration'
 const PrismicScript = () => {
   const [, repoName] = apiEndpoint.match(/https?:\/\/([^.]+)?\.(cdn\.)?.+/);
   return (
-    <script async defer type="text/javascript" src={`"https://static.cdn.prismic.io/prismic.min.js?repo=${repoName}&new=true"`} />
+    <script async defer src={`"https://static.cdn.prismic.io/prismic.min.js?repo=${repoName}&new=true"`} />
   )
 }
 


### PR DESCRIPTION
I had to remove my last change and add the script that matches the one we have in the docs. 
I also found out that the type attribute: <script type="text/javascript"> is not required. JavaScript is the default scripting language in HTML.