### PR TITLE
fix: do not cache `/api/exit-preview`

### DIFF
--- a/pages/api/exit-preview.js
+++ b/pages/api/exit-preview.js
@@ -1,5 +1,8 @@
-import * as prismicNext from "@prismicio/next";
+export default async function handler(_req, res) {
+  res.setHeader("Cache-Control", "no-store; max-age=0");
 
-export default async function handler(req, res) {
-  prismicNext.exitPreview({ res, req });
+  // Exit the current user from Preview Mode.
+  res.clearPreviewData();
+
+  res.json({ success: true });
 }

--- a/pages/api/exit-preview.js
+++ b/pages/api/exit-preview.js
@@ -4,5 +4,5 @@ export default async function handler(_req, res) {
   // Exit the current user from Preview Mode.
   res.clearPreviewData();
 
-  res.json({ success: true });
+  res.json({ success: true, foo: "bar" });
 }

--- a/pages/api/exit-preview.js
+++ b/pages/api/exit-preview.js
@@ -1,6 +1,4 @@
-export default async function handler(_req, res) {
-  res.setHeader("Cache-Control", "no-store; max-age=0");
-
+export default function handler(_req, res) {
   // Exit the current user from Preview Mode.
   res.clearPreviewData();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to starter maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR ensures `/api/exit-preview` is not cached.

Before this PR, previews could not be exited unless caching was disabled in the browser (not the default).

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
